### PR TITLE
refactor: 배치 쿼리 조회로 전환

### DIFF
--- a/src/main/java/com/codeit/weatherfit/domain/feed/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/weatherfit/domain/feed/repository/CommentRepository.java
@@ -4,7 +4,9 @@ import com.codeit.weatherfit.domain.feed.entity.Comment;
 import com.codeit.weatherfit.domain.feed.entity.Feed;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
@@ -12,4 +14,9 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
     Long countByFeed(Feed feed);
 
     void deleteByFeed(Feed feed);
+
+    @Query("select c.feed.id, count(c) from Comment c " +
+            "where c.feed.id in :feedIds " +
+            "group by c.feed.id")
+    List<Object[]> countByFeedIn(List<UUID> feedIds);
 }

--- a/src/main/java/com/codeit/weatherfit/domain/feed/repository/FeedClothesRepository.java
+++ b/src/main/java/com/codeit/weatherfit/domain/feed/repository/FeedClothesRepository.java
@@ -4,6 +4,7 @@ import com.codeit.weatherfit.domain.feed.entity.Feed;
 import com.codeit.weatherfit.domain.feed.entity.FeedClothes;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,4 +18,7 @@ public interface FeedClothesRepository extends JpaRepository<FeedClothes, UUID> 
     List<String> findAllImageKeys();
 
     void deleteByFeed(Feed feed);
+
+    @Query("select fc from FeedClothes fc where fc.feed.id in :feedIds")
+    List<FeedClothes> findAllFeedClothesByFeeds(@Param("feedIds") List<UUID> feedIds);
 }

--- a/src/main/java/com/codeit/weatherfit/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/codeit/weatherfit/domain/feed/repository/FeedLikeRepository.java
@@ -5,7 +5,11 @@ import com.codeit.weatherfit.domain.feed.entity.FeedLike;
 import com.codeit.weatherfit.domain.user.entity.User;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
@@ -16,4 +20,13 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, UUID> {
     boolean existsByFeedAndLikedUser(Feed feed, User likedUser);
 
     void deleteByFeedAndLikedUser(Feed feed, User likedUser);
+
+    @Query("select fl.feed.id, count(fl) from FeedLike fl " +
+            "where fl.feed.id in :feedIds " +
+            "group by fl.feed.id")
+    List<Object[]> countByFeedIn(@Param("feedIds") List<UUID> feedIds);
+
+    @Query("select fl.feed.id from FeedLike fl " +
+            "where fl.feed.id in :feedIds and fl.likedUser = :user")
+    Set<UUID> findLikedFeedIds(@Param("feedIds") List<UUID> feedIds, @Param("user") User user);
 }

--- a/src/main/java/com/codeit/weatherfit/domain/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/codeit/weatherfit/domain/feed/service/FeedServiceImpl.java
@@ -11,10 +11,7 @@ import com.codeit.weatherfit.domain.feed.dto.Ootd;
 import com.codeit.weatherfit.domain.feed.dto.request.*;
 import com.codeit.weatherfit.domain.feed.dto.response.CommentGetResponse;
 import com.codeit.weatherfit.domain.feed.dto.response.FeedGetResponse;
-import com.codeit.weatherfit.domain.feed.entity.Comment;
-import com.codeit.weatherfit.domain.feed.entity.Feed;
-import com.codeit.weatherfit.domain.feed.entity.FeedClothes;
-import com.codeit.weatherfit.domain.feed.entity.FeedLike;
+import com.codeit.weatherfit.domain.feed.entity.*;
 import com.codeit.weatherfit.domain.feed.event.FeedCreatedEvent;
 import com.codeit.weatherfit.domain.feed.event.FeedDeletedEvent;
 import com.codeit.weatherfit.domain.feed.event.FeedUpdatedEvent;
@@ -23,7 +20,6 @@ import com.codeit.weatherfit.domain.feed.repository.CommentRepository;
 import com.codeit.weatherfit.domain.feed.repository.FeedClothesRepository;
 import com.codeit.weatherfit.domain.feed.repository.FeedLikeRepository;
 import com.codeit.weatherfit.domain.feed.repository.FeedRepository;
-import com.codeit.weatherfit.domain.feed.repository.search.FeedSearchRepository;
 import com.codeit.weatherfit.domain.feed.service.search.FeedSearchService;
 import com.codeit.weatherfit.domain.follow.entity.Follow;
 import com.codeit.weatherfit.domain.follow.repository.FollowRepository;
@@ -45,10 +41,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -69,7 +63,6 @@ public class FeedServiceImpl implements FeedService {
     private final FollowRepository followRepository;
     private final ClothesAttributeRepository clothesAttributeRepository;
     private final FeedSearchService feedSearchService;
-    private final FeedSearchRepository feedSearchRepository;
 
     @Override
     @Transactional
@@ -144,9 +137,7 @@ public class FeedServiceImpl implements FeedService {
         boolean hasNext = lastFeed != null;
         log.info("피드 커서 조회 완료: count={}, hasNext={}", feeds.size(), hasNext);
         return new FeedGetResponse(
-                feeds.stream()
-                        .map(f -> this.toFeedDto(f, loginUser))
-                        .toList(),
+                toFeedDtos(feeds, loginUser),
                 hasNext ? lastFeed.getCreatedAt() : null,
                 hasNext ? lastFeed.getId() : null,
                 hasNext,
@@ -307,18 +298,56 @@ public class FeedServiceImpl implements FeedService {
     }
 
     private FeedDto toFeedDto(Feed feed, User loginUser) {
-        return FeedDto.from(
-                feed,
-                feedClothesRepository.findAllByFeed(feed).stream()
-                        .map(FeedClothes::getClothesSnapshot)
-                        .map(cs -> Ootd.from(
-                                cs,
-                                cs.imageKey() == null? null : s3Service.getUrl(cs.imageKey())
-                        )).toList(),
-                feedLikeRepository.countByFeed(feed),
-                commentRepository.countByFeed(feed),
-                feedLikeRepository.existsByFeedAndLikedUser(feed, loginUser)
-        );
+        return toFeedDtos(List.of(feed), loginUser).getFirst();
+    }
+
+    private List<FeedDto> toFeedDtos(List<Feed> feeds, User loginUser) {
+        if(feeds.isEmpty()) return List.of();
+
+        List<UUID> feedIds = feeds.stream().map(Feed::getId).toList();
+        Map<UUID, List<ClothesSnapshot>> feedMap = loadSnapshotMap(feedIds);
+        Map<UUID, Long> likeMap = loadLikeCountMap(feedIds);
+        Map<UUID, Long> commentMap = loadCommentCountMap(feedIds);
+        Set<UUID> likedFeedSet = feedLikeRepository.findLikedFeedIds(feedIds, loginUser);
+
+        return feeds.stream()
+                .map(feed -> FeedDto.from(
+                        feed,
+                        toOotds(feedMap.getOrDefault(feed.getId(), List.of())),
+                        likeMap.getOrDefault(feed.getId(), 0L),
+                        commentMap.getOrDefault(feed.getId(), 0L),
+                        likedFeedSet.contains(feed.getId())
+                )).toList();
+    }
+
+    private List<Ootd> toOotds(List<ClothesSnapshot> clothesSnapshots) {
+        return clothesSnapshots.stream()
+                .map(cs -> cs.imageKey() == null? null : Ootd.from(cs, s3Service.getUrl(cs.imageKey())))
+                .toList();
+    }
+
+    private Map<UUID, Long> loadCommentCountMap(List<UUID> feedIds) {
+        return commentRepository.countByFeedIn(feedIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> (Long) row[1]
+                ));
+    }
+
+    private Map<UUID, Long> loadLikeCountMap(List<UUID> feedIds) {
+        return feedLikeRepository.countByFeedIn(feedIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> (Long) row[1]
+                ));
+    }
+
+    private Map<UUID, List<ClothesSnapshot>> loadSnapshotMap(List<UUID> feedIds) {
+        return feedClothesRepository.findAllFeedClothesByFeeds(feedIds).stream()
+                .collect(Collectors.groupingBy(
+                        fc -> fc.getFeed().getId(),
+                        Collectors.mapping(FeedClothes::getClothesSnapshot, Collectors.toList())
+                ));
     }
 
     private Feed getFeedOrThrow(UUID id) {

--- a/src/test/java/com/codeit/weatherfit/domain/feed/service/unit/FeedServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherfit/domain/feed/service/unit/FeedServiceImplTest.java
@@ -39,9 +39,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -96,8 +94,6 @@ class FeedServiceImplTest {
     @Mock
     com.codeit.weatherfit.domain.feed.service.search.FeedSearchService feedSearchService;
 
-    @Mock
-    com.codeit.weatherfit.domain.feed.repository.search.FeedSearchRepository feedSearchRepository;
 
     @Nested
     @DisplayName("생성")
@@ -123,7 +119,7 @@ class FeedServiceImplTest {
                     .thenReturn(List.of("옵션1"));
             when(followRepository.findAllByFollowee(any(User.class)))
                     .thenReturn(List.of());
-            stubToFeedDto();
+            stubToFeedDtos();
 
             // when
             feedService.create(request, userDetails);
@@ -215,7 +211,7 @@ class FeedServiceImplTest {
             String newContent = "새로바뀝";
             when(feedRepository.findById(any(UUID.class)))
                     .thenReturn(Optional.of(feed));
-            stubToFeedDto();
+            stubToFeedDtos();
             FeedUpdateRequest feedUpdateRequest = new FeedUpdateRequest(newContent);
 
             // when
@@ -268,7 +264,7 @@ class FeedServiceImplTest {
             when(feedRepository.findWithCursor(request)).thenReturn(feeds);
             when(userRepository.findById(loginUser.getId()))
                     .thenReturn(Optional.of(loginUser));
-            stubToFeedDto();
+            stubToFeedDtos();
 
             // when
             FeedGetResponse response = feedService.getFeedsByCursor(request, userDetails);
@@ -300,7 +296,7 @@ class FeedServiceImplTest {
             when(feedRepository.findWithCursor(request)).thenReturn(feeds);
             when(userRepository.findById(loginUser.getId()))
                     .thenReturn(Optional.of(loginUser));
-            stubToFeedDto();
+            stubToFeedDtos();
 
             // when
             FeedGetResponse response = feedService.getFeedsByCursor(request, userDetails);
@@ -737,17 +733,15 @@ class FeedServiceImplTest {
         }
     }
 
-    private void stubToFeedDto() {
-        when(feedClothesRepository.findAllByFeed(any(Feed.class)))
-                .thenReturn(Instancio.createList(FeedClothes.class));
-        when(feedLikeRepository.countByFeed(any(Feed.class)))
-                .thenReturn(0L);
-        when(commentRepository.countByFeed(any(Feed.class)))
-                .thenReturn(0L);
-        when(feedLikeRepository.existsByFeedAndLikedUser(any(Feed.class), any(User.class)))
-                .thenReturn(false);
-        when(s3Service.getUrl(any()))
-                .thenReturn("http://localhost:8080/image/1234567890");
+    private void stubToFeedDtos() {
+        when(feedClothesRepository.findAllFeedClothesByFeeds(anyList()))
+                .thenReturn(List.of());
+        when(feedLikeRepository.countByFeedIn(anyList()))
+                .thenReturn(List.of());
+        when(commentRepository.countByFeedIn(anyList()))
+                .thenReturn(List.of());
+        when(feedLikeRepository.findLikedFeedIds(anyList(), any(User.class)))
+                .thenReturn(new HashSet<>());
     }
 
 }


### PR DESCRIPTION
### 변경 사항

**피드 목록 조회 배치 쿼리 전환 (N+1 해소)**
- `FeedServiceImpl.toFeedDtos()` — 피드 목록 변환 시 좋아요 수, 댓글 수, 옷 스냅샷, 좋아요 여부를 배치 쿼리 4건으로 조회하도록 전환
- `FeedServiceImpl.toFeedDto()` — 단건 조회도 `toFeedDtos(List.of(feed))`로 위임하여 코드 중복 제거
- `FeedLikeRepository.countByFeedIn()` — feedId 리스트로 좋아요 수 집계 (GROUP BY)
- `FeedLikeRepository.findLikedFeedIds()` — feedId 리스트 + 로그인 유저로 좋아요 여부 일괄 조회
- `CommentRepository.countByFeedIn()` — feedId 리스트로 댓글 수 집계 (GROUP BY)
- `FeedClothesRepository.findAllFeedClothesByFeeds()` — feedId 리스트로 FeedClothes 일괄 조회

**기타**
- `FeedServiceImpl` — 미사용 `FeedSearchRepository` 의존성 제거
- `toFeedDtos()` 빈 리스트 방어 코드 추가

### 코멘트 (선택)

- 기존: 피드 N건 조회 시 피드마다 좋아요 수, 댓글 수, 스냅샷, 좋아요 여부 개별 쿼리 → 최대 4N+1 쿼리
- 변경: 4건의 배치 쿼리(IN 절)로 고정 → 피드 수에 관계없이 쿼리 수 일정
- 집계 쿼리(`countByFeedIn`)는 결과가 없는 feedId에 대해 row가 생성되지 않으므로, `getOrDefault(feedId, 0L)`로 기본값 처리