### PR TITLE
feat: ecs환경에서 openrouter 호출 시 헤더값의 검증을 위해서

### DIFF
--- a/src/main/java/com/codeit/weatherfit/domain/recommendation/AiConfig.java
+++ b/src/main/java/com/codeit/weatherfit/domain/recommendation/AiConfig.java
@@ -48,7 +48,9 @@ public class AiConfig {
 
         // 2. 위에서 만든 설정을 사용하는 RestClient.Builder 생성
         RestClient.Builder restClientBuilder = RestClient.builder()
-                .requestFactory(requestFactory);
+                .requestFactory(requestFactory)
+                .defaultHeader("HTTP-Referer", "https://weatherfit.cloud")
+                .defaultHeader("X-Title", "WeatherFit");
         return OpenAiApi.builder()
                 .apiKey(OPENROUTER_API_KEY)
                 .baseUrl(OPENAI_BASE_URL)


### PR DESCRIPTION
### 변경 사항

- ecs서버에서 openrouter 호출 시에 자꾸 문제가 발생하는데, 찾아보니 ecs 환경에서 오는 호출에 대해서는 openrouter가 더 꼼꼼히 검사해서 그런 걸 수도 있다네요. 우선 확실하진 않지만 헤더 값 2개를 추가했습니다. 로컬에서는 정상 동작합니다.
-

### 코멘트 (선택)