### PR TITLE
feat: 옷 삭제와 유저의 온도 민감도 변경 시 옷 추천 캐시 삭제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,5 @@
 
 services:
-  postgres:
-    image: postgres:16-alpine
-    container_name: postgres
-    ports:
-      - "5432:5432"
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: weatherFit
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-    networks:
-      - weatherfit-net
-
   redis:
     image: redis:7.2-alpine
     container_name: redis

--- a/src/main/java/com/codeit/weatherfit/domain/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/codeit/weatherfit/domain/clothes/repository/ClothesRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -17,6 +18,11 @@ public interface ClothesRepository extends JpaRepository<Clothes, UUID>, Clothes
             UUID ownerId,
             Pageable pageable
     );
+
+    @Query("select c from Clothes c " +
+            " join fetch c.owner" +
+            " where c.id = :clothesId")
+    Optional<Clothes> findWithOwnerById(@Param("clothesId") UUID clothesId);
 
     List<Clothes> findByOwnerId(UUID ownerId);
 

--- a/src/main/java/com/codeit/weatherfit/domain/clothes/service/ClothesServiceImpl.java
+++ b/src/main/java/com/codeit/weatherfit/domain/clothes/service/ClothesServiceImpl.java
@@ -26,9 +26,11 @@ import org.jsoup.nodes.Document;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -47,7 +49,7 @@ public class ClothesServiceImpl implements ClothesService {
     private final ClothesAttributeTypeRepository clothesAttributeTypeRepository;
     private final ClothesAttributeRepository clothesAttributeRepository;
     private final S3Service s3Service;
-    private final ApplicationEventPublisher eventPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     @Transactional
@@ -111,6 +113,7 @@ public class ClothesServiceImpl implements ClothesService {
                 clothesAttributeRepository.save(clothesAttribute);
             }
 
+            redisDelete(ownerId);
         }
 
 
@@ -201,6 +204,8 @@ public class ClothesServiceImpl implements ClothesService {
         if (clothes.getImageKey() != null) {
             s3Service.delete(clothes.getImageKey());
         }
+
+        redisDelete(clothes.getOwner().getId());
     }
 
     @Override
@@ -300,5 +305,10 @@ public class ClothesServiceImpl implements ClothesService {
         } catch (IOException e) {
             throw new ClothesExtractionException(ErrorCode.URL_PARSING_FAILED);
         }
+    }
+
+    private void redisDelete(UUID userId){
+        String key = "rec:pool:" + userId;
+        redisTemplate.delete(key);
     }
 }

--- a/src/main/java/com/codeit/weatherfit/domain/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/codeit/weatherfit/domain/profile/service/ProfileServiceImpl.java
@@ -16,6 +16,7 @@ import com.codeit.weatherfit.global.s3.exception.S3UploadException;
 import com.codeit.weatherfit.global.s3.util.S3KeyGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +35,7 @@ public class ProfileServiceImpl implements ProfileService {
     private final ProfileLocationResolver profileLocationResolver;
     private final ApplicationEventPublisher eventPublisher;
     private final S3Service s3Service;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     @Transactional(readOnly = true)
@@ -78,10 +80,16 @@ public class ProfileServiceImpl implements ProfileService {
             }
         }
 
+        if(request.temperatureSensitivity() != profile.getTemperatureSensitivity()) {
+            redisDelete(userId);
+        }
+
         profile.updateGender(request.gender());
         profile.updateBirthDate(request.birthDate());
         profile.updateLocation(location);
         profile.updateTemperatureSensitivity(request.temperatureSensitivity());
+
+
 
         return ProfileDto.from(profile, getProfileImageUrl(profile));
     }
@@ -100,5 +108,10 @@ public class ProfileServiceImpl implements ProfileService {
             return null;
         }
         return s3Service.getUrl(profileImageKey);
+    }
+
+    private void redisDelete(UUID userId){
+        String key = "rec:pool:" + userId;
+        redisTemplate.delete(key);
     }
 }

--- a/src/main/java/com/codeit/weatherfit/domain/recommendation/service/RecommendationServiceImpl.java
+++ b/src/main/java/com/codeit/weatherfit/domain/recommendation/service/RecommendationServiceImpl.java
@@ -35,7 +35,6 @@ public class RecommendationServiceImpl implements RecommendationService {
     private final S3Service s3Service;
     private final RedisTemplate<String, Object> redisTemplate;
     private final AiClothesRecommender aiClothesRecommender;
-    //    private final ClothesAttributeTypeRepository clothesAttributeTypeRepository;
     private final ClothesAttributeRepository clothesAttributeRepository;
     private final SelectableValueRepository selectableValueRepository;
 

--- a/src/main/java/com/codeit/weatherfit/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/weatherfit/domain/user/service/UserServiceImpl.java
@@ -22,6 +22,7 @@ import com.codeit.weatherfit.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/com/codeit/weatherfit/domain/clothes/service/ClothesServiceImplTest.java
+++ b/src/test/java/com/codeit/weatherfit/domain/clothes/service/ClothesServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.web.multipart.MultipartFile;
 import java.util.*;
 
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.*;
     @Mock private ClothesAttributeRepository clothesAttributeRepository;
     @Mock private S3Service s3Service;
     @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
 
     @Nested
     class Create {
@@ -225,6 +227,11 @@ import static org.mockito.Mockito.*;
         void success() {
             UUID id = UUID.randomUUID();
             Clothes clothes = mock(Clothes.class);
+            User owner = mock(User.class); // Owner용 Mock 추가
+
+
+            when(clothes.getOwner()).thenReturn(owner);
+            when(owner.getId()).thenReturn(id);
 
             when(clothesRepository.findById(id))
                     .thenReturn(Optional.of(clothes));

--- a/src/test/java/com/codeit/weatherfit/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/weatherfit/domain/notification/service/NotificationServiceTest.java
@@ -37,8 +37,6 @@ class NotificationServiceTest {
     @Autowired
     EntityManager em;
     @MockitoBean
-    private KafkaTemplate<String, MessageCreatedEvent> kafkaTemplate;
-    @MockitoBean
     private FeedSearchRepository feedSearchRepository;
 
 


### PR DESCRIPTION
### 변경 사항

- 옷 삭제 시에 레디스에 유저의 아이디를 포함한 키로 추천된 캐시를 삭제하는 로직을 추가하였습니다.
- 관련돼서 효율성을 위해 유저를 같이 조회하는 쿼리로 변경하였고, 테스트도 수정하였습니다
- 유저의 온도가 변경될 경우, 옷 추천 캐시를 삭제하는 로직을 추가하였습니다.

### 코멘트 (선택)
도겸 님 코드가 수정된 부분이 조금 더 있으니 확인 부탁드릴게요.
추가적으로 의미없는 코드들도 삭제하였습니다.(컴포즈 파일의 postgres 등)